### PR TITLE
fix to avoid builder to crash the app when scss files do not exist #49

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -93,7 +93,9 @@ function buildHTML(params, key, cb) {
   gulp.src(markupFiles)
     .pipe(concat('./markup' + new Date().getTime()))
     .pipe(gutil.buffer(function(err, data) {
-      console.log(err);
+      if (err) {
+        console.log(err);
+      }
       cb && cb(err, key, data);
     }));
 }
@@ -137,6 +139,11 @@ function buildJS(params, key, cb) {
 }
 
 function process(res, data) {
+  if (!data.buffer[0]) {
+    console.log('no data content to return');
+    res.end();
+    return;
+  }
   var contents = data.buffer[0]._contents;
 
   if (data.minified) {


### PR DESCRIPTION
There might be a problem of consistency between the CSS class naming, SCSS file naming, and keys define in deps.json.

If there is an inconsistency the app might crash.

This patch try to avoid the crash.