### PR TITLE
Enabled scaling of textareas on the site

### DIFF
--- a/site/css/src/base/_globals.scss
+++ b/site/css/src/base/_globals.scss
@@ -71,14 +71,15 @@ fieldset {
 }
 
 textarea {
+  box-sizing: border-box;
   display: block;
   min-height: 150px;
   width: 100%;
+  max-width: 100%;
   border: none;
   resize: none;
   background: #312B56;
   border: none;
-  resize: none;
   border-radius: 2px;
   padding: 12px;
   font-family: monospace;


### PR DESCRIPTION
Re-enabled scaling of the textareas on the site (limited the width to only allow vertical resizing by the user).
Set their box sizing to border-box to prevent horizontal scrollbars on the prism.js containers caused by the padding on the textareas.
![before_after](https://cloud.githubusercontent.com/assets/105719/6204622/70600186-b552-11e4-9528-c82305f6f076.png)
