### PR TITLE
Removed leftover resize: none;

### DIFF
--- a/site/css/src/base/_globals.scss
+++ b/site/css/src/base/_globals.scss
@@ -77,7 +77,6 @@ textarea {
   width: 100%;
   max-width: 100%;
   border: none;
-  resize: none;
   background: #312B56;
   border: none;
   border-radius: 2px;


### PR DESCRIPTION
There was another `resize: none;` line left after https://github.com/grayghostvisuals/transformicons/commit/37c6ab259409a139b5189cd9749878013bf0176f. This commit fixes that and makes the textareas finally resizable. :)